### PR TITLE
Added response.resume() to fix getaddrinfo ENOTFOUND

### DIFF
--- a/lib/GithubTimelineStream.js
+++ b/lib/GithubTimelineStream.js
@@ -96,6 +96,8 @@ function GithubTimelineStream (opts) {
                   console.log("Github-timeline-stream: You have exhausted your requests.  Consider authenticating");
                   pauseUntil = parseInt(response.headers['x-ratelimit-reset'], 10);
               }
+
+              response.resume();
           })
           .on('error', function(e){
               console.log("Github-timeline-stream: Error getting page: " + e);


### PR DESCRIPTION
This seems to fix the issue. I was getting the error after just a few minutes of running. With this added, it ran for over an hour with no issues at all.

Here is a reference to a similar issue:
[issue #699](https://github.com/request/request/issues/699#issuecomment-27851924)
